### PR TITLE
Optimize container size by cleaning up after apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.10-stretch
 # Install software
-RUN apt-get update
-RUN apt-get install -y bind9 python3 python3-pip
+RUN apt-get update \
+ && apt-get install -y bind9 python3 python3-pip \
+ && apt-get clean all \
+ && rm -rf /var/lib/apt/lists/*;
 ADD requirements.txt /root/
 RUN pip3 install -r /root/requirements.txt
 # Setup bind9


### PR DESCRIPTION
As suggested by @mattclay in #1.