### PR TITLE
Using two-stage build to improve container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM golang:1.10-stretch
+FROM golang:1.10-stretch as builder
+# Install pebble
+ARG PEBBLE_CHECKOUT="25448686e9b499e42380ddf965d8e23bd794378c"
+ENV GOPATH=/go
+RUN go get -u github.com/letsencrypt/pebble/... && \
+    cd /go/src/github.com/letsencrypt/pebble && \
+    git checkout ${PEBBLE_CHECKOUT} && \
+    go install ./...
+
+FROM debian:stretch-slim
 # Install software
 RUN apt-get update \
  && apt-get install -y bind9 python3 python3-pip \
@@ -10,12 +19,9 @@ RUN pip3 install -r /root/requirements.txt
 ADD bind.conf /etc/bind/named.conf
 RUN mkdir /etc/bind/zones
 # Install pebble
-ARG PEBBLE_CHECKOUT="25448686e9b499e42380ddf965d8e23bd794378c"
-ENV GOPATH=/go
-RUN go get -u github.com/letsencrypt/pebble/... && \
-    cd /go/src/github.com/letsencrypt/pebble && \
-    git checkout ${PEBBLE_CHECKOUT} && \
-    go install ./...
+COPY --from=builder /go/bin /go/bin
+COPY --from=builder /go/pkg /go/pkg
+COPY --from=builder /go/src/github.com/letsencrypt/pebble/test /go/src/github.com/letsencrypt/pebble/test
 ADD pebble-config.json /go/src/github.com/letsencrypt/pebble/test/config/pebble-config.json
 # Setup controller.py and run.sh
 ADD run.sh controller.py acme_tlsalpn.py LICENSE LICENSE-acme README.md /root/


### PR DESCRIPTION
Another try for optimizing container size. Uses a two-stage build process.

I haven't managed to use a smaller Python-specific image for the second step; installing bind9 always resulted in installing bind9utils, which carried Python 3.5 along, and after that Python was kind of broken...
