### PR TITLE
bump Pebble version; enable Pebble strict mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="804565139f41a8db54df28decc1b967e4003f8bd"
+ARG PEBBLE_CHECKOUT="501c9cb79684dde81d2ad88039ccaa2a2f5ea7c2"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="501c9cb79684dde81d2ad88039ccaa2a2f5ea7c2"
+ARG PEBBLE_CHECKOUT="35f569333bca2b780147889c42d9f75fa8770057"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/controller.py
+++ b/controller.py
@@ -131,7 +131,7 @@ def _get_alpn_key_cert_from_der_value(domain, data):
     key = crypto.PKey()
     key.generate_key(crypto.TYPE_RSA, 2048)
     # Create self-signed certificates
-    acme_extension = crypto.X509Extension(b"1.3.6.1.5.5.7.1.30.1", critical=True, value=der_value)
+    acme_extension = crypto.X509Extension(b"1.3.6.1.5.5.7.1.31", critical=True, value=der_value)
     cert_challenge = gen_ss_cert(key, [domain], extensions=[acme_extension])
     return key, cert_challenge
 

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,4 @@ export CONTROLLER_PORT=5000
 export PEBBLE_VA_SLEEPTIME=5
 # Start Pebble
 cd /go/src/github.com/letsencrypt/pebble
-/go/bin/pebble -config /go/src/github.com/letsencrypt/pebble/test/config/pebble-config.json
+/go/bin/pebble -config /go/src/github.com/letsencrypt/pebble/test/config/pebble-config.json -strict true


### PR DESCRIPTION
What's new:
- Enables Pebble's strict mode.
- Bump Pebble version
  - includes letsencrypt/pebble#151, which allows key rollover tests

There might be some more new features during the next days, so let's wait until the end of this week or so :)