### PR TITLE
Upgrade Pebble to new version which requires POST-as-GET in strict mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="35f569333bca2b780147889c42d9f75fa8770057"
+ARG PEBBLE_CHECKOUT="6133f3e187a93ddf81f509123dfe9f5b60d519bf"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \


### PR DESCRIPTION
Updates to the latest Pebble version. Most notable change is support of [draft-15](https://tools.ietf.org/html/draft-ietf-acme-acme-15) of the ACME protocol, which mandates POST-as-GET for more some resources (letsencrypt/pebble#162, letsencrypt/pebble#168). This is needed to test ansible/ansible#44988.