### PR TITLE
Add support for IP certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="bc4da68d49d78a38bfea869d38faadc8c714654c"
+ARG PEBBLE_CHECKOUT="c5de6e0ed64c8854fd27f85067ccbbb2dbe77862"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="c5de6e0ed64c8854fd27f85067ccbbb2dbe77862"
+ARG PEBBLE_CHECKOUT="7228963479dd2bce0c040049b18e67393155bc6a"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-stretch as builder
 # Install pebble
-ARG PEBBLE_CHECKOUT="1f851bf3f6b0c22d2f59c1e8958b79e0ab7ad580"
+ARG PEBBLE_CHECKOUT="bc4da68d49d78a38bfea869d38faadc8c714654c"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/controller.py
+++ b/controller.py
@@ -129,10 +129,10 @@ def _get_alpn_key_cert_from_der_value(domain, identifier, data):
     der_value = b"DER:0420" + codecs.encode(base64.standard_b64decode(data), 'hex')
     domains = []
     ips = []
-    if identifier.startswith('DNS:'):
-        domains.add(identifier[4:])
-    elif identifier.startswith('IP:'):
-        ips.add(identifier[3:])
+    if identifier.upper().startswith('DNS:'):
+        domains.append(identifier[4:])
+    elif identifier.upper().startswith('IP:'):
+        ips.append(identifier[3:])
     # Create private key
     key = crypto.PKey()
     key.generate_key(crypto.TYPE_RSA, 2048)


### PR DESCRIPTION
Now that letsencrypt/pebble#221 has finally be merged, add changes from felixfontein/ansible-acme-test#1 so I can add proper integration tests for IP certificates to Ansible's acme_certificate tests (similar as in felixfontein/ansible-acme-test#1).