### PR TITLE
New Pebble version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM golang:1.12-stretch as builder
 # Install pebble
+ARG PEBBLE_REMOTE=
 ARG PEBBLE_CHECKOUT="c65a2f3c2be48868db01363f32d1d99c77281946"
 ENV GOPATH=/go
 RUN go get -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \
-    git checkout ${PEBBLE_CHECKOUT} && \
+    if [ "${PEBBLE_REMOTE}" != "" ]; then \
+      git remote add other ${PEBBLE_REMOTE} && \
+      git fetch other && \
+      git checkout -b other-${PEBBLE_CHECKOUT} --track other/${PEBBLE_CHECKOUT}; \
+    else \
+      git checkout ${PEBBLE_CHECKOUT}; \
+    fi && \
     go install ./...
 
 FROM python:3.6-slim-stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-stretch as builder
 # Install pebble
 ARG PEBBLE_REMOTE=
-ARG PEBBLE_CHECKOUT="c65a2f3c2be48868db01363f32d1d99c77281946"
+ARG PEBBLE_CHECKOUT="7e026bbfe639ff65dbafacd1b4259a660a8c513f"
 ENV GOPATH=/go
 RUN go get -v -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13-stretch as builder
 ARG PEBBLE_REMOTE=
 ARG PEBBLE_CHECKOUT="c65a2f3c2be48868db01363f32d1d99c77281946"
 ENV GOPATH=/go
-RUN go get -u github.com/letsencrypt/pebble/... && \
+RUN go get -v -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \
     if [ "${PEBBLE_REMOTE}" != "" ]; then \
       git remote add other ${PEBBLE_REMOTE} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch as builder
+FROM golang:1.13-stretch as builder
 # Install pebble
 ARG PEBBLE_REMOTE=
 ARG PEBBLE_CHECKOUT="c65a2f3c2be48868db01363f32d1d99c77281946"

--- a/controller.py
+++ b/controller.py
@@ -226,7 +226,7 @@ def get_root_certificate_pebble(index):
     return urllib.request.urlopen("https://localhost:15000/roots/{0}".format(index), context=ctx).read()
 
 
-@app.route('/intermediate-certificate-for-ca<int:index>')
+@app.route('/intermediate-certificate-for-ca/<int:index>')
 def get_intermediate_certificate_pebble(index):
     ctx = ssl.create_default_context()
     ctx.check_hostname = False


### PR DESCRIPTION
Pebble has some useful updates needed for ansible/ansible#60710:
 - Bugfix letsencrypt/pebble#276: Make sure all intermediate certificates have the same subject;
 - Feature letsencrypt/pebble#269: Add SubjectKeyId to certificates.

This also fixes a small typo in the controller (intermediate CA certificates endpoint), and uses a newer Go version (1.13) to build Pebble.

Also, I've changed `Dockerfile` to allow building from different remotes (by setting `PEBBLE_REMOTE`). This is very useful to build local testing containers from branches outside the Pebble main repository (for example from my fork :) ).