### PR TITLE
Bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-stretch as builder
 # Install pebble
 ARG PEBBLE_REMOTE=
-ARG PEBBLE_CHECKOUT="7e026bbfe639ff65dbafacd1b4259a660a8c513f"
+ARG PEBBLE_CHECKOUT="746c32eb265131059a2a340388a4bc7c37405cfc"
 ENV GOPATH=/go
 RUN go get -v -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Flask==1.0.2
-Werkzeug==0.14.1
-pyOpenSSL==18.0.0
-dnslib==0.9.7
+Flask==1.1.1
+pyOpenSSL==19.0.0
+dnslib==0.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
+# Requirements
 Flask==1.1.1
 pyOpenSSL==19.0.0
 dnslib==0.9.10
+
+# Implicit requirements to make Python part reproducable
+Jinja2==2.10.3
+MarkupSafe==1.1.1
+Werkzeug==0.16.0
+cffi==1.13.2
+click==7.0
+cryptography==2.8
+itsdangerous==1.1.0
+pycparser==2.19
+six==1.12.0


### PR DESCRIPTION
Closes #17 (removing Werkzeug as an explicit dependency, bumping Python dependencies in general to latest versions). Also bumps Pebble version to latest, which includes letsencrypt/pebble#281 and letsencrypt/pebble#286.

The security issues of Werkzeug (https://palletsprojects.com/blog/categories/security/) are probably not relevant in our use-case, but it doesn't hurt to use a fixed version.

The current set of Python packages installed is Flask-1.1.1 Jinja2-2.10.3 MarkupSafe-1.1.1 Werkzeug-0.16.0 cffi-1.13.2 click-7.0 cryptography-2.8 dnslib-0.9.10 itsdangerous-1.1.0 pyOpenSSL-19.0.0 pycparser-2.19 six-1.12.0.

I ran the acme_certificate tests against this, everything still seems to work.