### PR TITLE
Add support for external account binding; add OCSP responder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !controller.py
 !dns_server.py
 !acme_tlsalpn.py
+!ocsp.py
 !create-pebble-config.py
 !README.md
 !LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-stretch as builder
 # Install pebble
 ARG PEBBLE_REMOTE=
-ARG PEBBLE_CHECKOUT="746c32eb265131059a2a340388a4bc7c37405cfc"
+ARG PEBBLE_CHECKOUT="05f79ba495ab6a27cbbc32e20b44afac52eb9914"
 ENV GOPATH=/go
 RUN go get -v -u github.com/letsencrypt/pebble/... && \
     cd /go/src/github.com/letsencrypt/pebble && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ COPY --from=builder /go/bin /go/bin
 COPY --from=builder /go/pkg /go/pkg
 COPY --from=builder /go/src/github.com/letsencrypt/pebble/test /go/src/github.com/letsencrypt/pebble/test
 # Setup controller.py and run.sh
-ADD run.sh controller.py dns_server.py acme_tlsalpn.py create-pebble-config.py LICENSE LICENSE-acme README.md /root/
-EXPOSE 5000 6000 14000
+ADD run.sh controller.py dns_server.py acme_tlsalpn.py ocsp.py create-pebble-config.py LICENSE LICENSE-acme README.md /root/
+EXPOSE 5000 14000
 CMD [ "/bin/sh", "-c", "/root/run.sh" ]

--- a/create-pebble-config.py
+++ b/create-pebble-config.py
@@ -32,7 +32,7 @@ config = {
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5000,
     "tlsPort": 5001,
-    "ocspResponderURL": "http://{0}:6000".format(own_ip),  # will be added later
+    "ocspResponderURL": "http://{0}:5000/ocsp".format(own_ip),  # will be added later
     "externalAccountBindingRequired": False,
     "externalAccountMACKeys": {
       "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",

--- a/create-pebble-config.py
+++ b/create-pebble-config.py
@@ -33,6 +33,15 @@ config = {
     "httpPort": 5000,
     "tlsPort": 5001,
     "ocspResponderURL": "http://{0}:6000".format(own_ip),  # will be added later
+    "externalAccountBindingRequired": False,
+    "externalAccountMACKeys": {
+      "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH",
+      "kid-3": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-4": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH",
+      "kid-5": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-6": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
+    }
   }
 }
 

--- a/ocsp.py
+++ b/ocsp.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+# (c) 2018 Felix Fontein (@felixfontein) <felix@fontein.de>
+#
+# Written by Felix Fontein <felix@fontein.de>
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import json
+import os
+import urllib
+import traceback
+
+from flask import Response
+
+from cryptography import x509
+from cryptography.x509 import ocsp
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+
+
+SAMPLE_REQUEST_CACHE = {}
+
+
+def _get_sample_request_for_root(root, hash_algorithm, pebble_urlopen):
+    '''
+    Returns an OCSP sample request for this root, together with the intermediate certificate and its key.
+    '''
+    cache_key = (root, hash_algorithm.name)
+    if cache_key in SAMPLE_REQUEST_CACHE:
+        return SAMPLE_REQUEST_CACHE[cache_key]
+
+    # Get hold of intermediate certificate with key
+    intermediate = x509.load_pem_x509_certificate(
+        pebble_urlopen("/intermediates/{0}".format(root)).read(),
+        backend=default_backend())
+    intermediate_key = serialization.load_pem_private_key(
+        pebble_urlopen("/intermediate-keys/{0}".format(root)).read(),
+        None,
+        backend=default_backend())
+
+    one_day = datetime.timedelta(1, 0, 0)
+    builder = x509.CertificateBuilder()
+    builder = builder.subject_name(intermediate.subject)
+    builder = builder.issuer_name(intermediate.subject)
+    builder = builder.not_valid_before(datetime.datetime.today() - one_day)
+    builder = builder.not_valid_after(datetime.datetime.today() + one_day)
+    builder = builder.serial_number(x509.random_serial_number())
+    builder = builder.public_key(intermediate.public_key())
+    certificate = builder.sign(
+        private_key=intermediate_key,
+        algorithm=hashes.SHA256(),
+        backend=default_backend())
+
+    req = ocsp.OCSPRequestBuilder()
+    req = req.add_certificate(certificate, intermediate, hash_algorithm)
+    req = req.build()
+
+    result = req, intermediate, intermediate_key
+    SAMPLE_REQUEST_CACHE[cache_key] = result
+    return result
+
+
+RECOVATION_REASONS = {
+    1: x509.ReasonFlags.key_compromise,
+    2: x509.ReasonFlags.ca_compromise,
+    3: x509.ReasonFlags.affiliation_changed,
+    4: x509.ReasonFlags.superseded,
+    5: x509.ReasonFlags.cessation_of_operation,
+    6: x509.ReasonFlags.certificate_hold,
+    7: x509.ReasonFlags.privilege_withdrawn,
+    8: x509.ReasonFlags.aa_compromise,
+}
+
+
+def _get_ocsp_response(data, pebble_urlopen, log):
+    try:
+        ocsp_request = ocsp.load_der_ocsp_request(data)
+    except Exception:
+        log('Error while decoding OCSP request')
+        return ocsp.OCSPResponseBuilder.build_unsuccessful(
+            ocsp.OCSPResponseStatus.MALFORMED_REQUEST)
+
+    log('OCSP request for certificate # {0}'.format(ocsp_request.serial_number))
+
+    # Process possible extensions
+    nonce = None
+    for ext in ocsp_request.extensions:
+        if isinstance(ext.value, x509.OCSPNonce):
+            nonce = ext.value.nonce
+            continue
+        if ext.critical:
+            return ocsp.OCSPResponseBuilder.build_unsuccessful(
+                ocsp.OCSPResponseStatus.MALFORMED_REQUEST)
+
+    # Determine issuer
+    root_count = int(os.environ.get('PEBBLE_ALTERNATE_ROOTS') or '0') + 1
+    for root in range(root_count):
+        req, intermediate, intermediate_key = _get_sample_request_for_root(
+            root, ocsp_request.hash_algorithm, pebble_urlopen)
+        if req.issuer_key_hash == ocsp_request.issuer_key_hash and req.issuer_name_hash == ocsp_request.issuer_name_hash:
+            log('Identified intermediate certificate {0}'.format(intermediate.subject))
+            break
+        intermediate = None
+        intermediate_key = None
+    if intermediate is None or intermediate_key is None:
+        log(ocsp_request.issuer_key_hash, ocsp_request.issuer_name_hash)
+        log('Cannot identify intermediate certificate')
+        return ocsp.OCSPResponseBuilder.build_unsuccessful(
+            ocsp.OCSPResponseStatus.UNAUTHORIZED)
+
+    serial_hex = hex(ocsp_request.serial_number)[2:]
+    if len(serial_hex) % 2 == 1:
+        serial_hex = '0' + serial_hex
+    try:
+        url = pebble_urlopen("/cert-status-by-serial/{0}".format(serial_hex))
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            log('Unknown certificate with # {0}'.format(ocsp_request.serial_number))
+            return ocsp.OCSPResponseBuilder.build_unsuccessful(
+                ocsp.OCSPResponseStatus.UNAUTHORIZED)
+        raise
+
+    data = json.loads(url.read())
+    log('Pebble result on certificate:', json.dumps(data, sort_keys=True, indent=2))
+
+    cert = x509.load_pem_x509_certificate(
+        data['Certificate'].encode('utf-8'), backend=default_backend())
+
+    now = datetime.datetime.now()
+    if data['Status'] == 'Revoked':
+        cert_status = ocsp.OCSPCertStatus.REVOKED
+        revoked_at = data.get('RevokedAt')
+        if revoked_at is not None:
+            revoked_at = ' '.join(revoked_at.split(' ')[:2])  # remove time zones
+            if '.' in revoked_at:
+                revoked_at = revoked_at[:revoked_at.index('.')]  # remove milli- or nanoseconds
+            revoked_at = datetime.datetime.strptime(revoked_at, '%Y-%m-%d %H:%M:%S')
+        revocation_time = revoked_at,
+        revocation_reason = RECOVATION_REASONS.get(data.get('Reason'), x509.ReasonFlags.unspecified)
+    elif data['Status'] == 'Valid':
+        cert_status = ocsp.OCSPCertStatus.GOOD
+        revocation_time = None
+        revocation_reason = None
+    else:
+        log('Unknown certificate status "{0}"'.format(data['Status']))
+        return ocsp.OCSPResponseBuilder.build_unsuccessful(
+            ocsp.OCSPResponseStatus.INTERNAL_ERROR)
+
+    response = ocsp.OCSPResponseBuilder()
+    response = response.add_response(
+        cert=cert,
+        issuer=intermediate,
+        algorithm=ocsp_request.hash_algorithm,
+        cert_status=cert_status,
+        this_update=now,
+        next_update=None,
+        revocation_time=revocation_time,
+        revocation_reason=revocation_reason)
+    response = response.responder_id(
+        ocsp.OCSPResponderEncoding.HASH,
+        intermediate)
+    if nonce is not None:
+        response = response.add_extension(x509.OCSPNonce(nonce), False)
+    return response.sign(intermediate_key, hashes.SHA256())
+
+
+def get_ocsp_response(data, pebble_urlopen, log=lambda *args: print(args)):
+    try:
+        response = _get_ocsp_response(data, pebble_urlopen, log=log)
+    except Exception as e:
+        log('Error while processing OCSP request: {0}'.format(e), traceback.format_exc())
+        response = ocsp.OCSPResponseBuilder.build_unsuccessful(
+            ocsp.OCSPResponseStatus.INTERNAL_ERROR)
+    return Response(
+        response.public_bytes(serialization.Encoding.DER),
+        mimetype='application/ocsp-response')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # Requirements
-Flask==1.1.1
-pyOpenSSL==19.0.0
-dnslib==0.9.10
+Flask==1.1.2
+pyOpenSSL==19.1.0
+dnslib==0.9.14
+cryptography==3.0
 
 # Implicit requirements to make Python part reproducable
-Jinja2==2.10.3
+Jinja2==2.11.2
 MarkupSafe==1.1.1
-Werkzeug==0.16.0
-cffi==1.13.2
-click==7.0
-cryptography==2.8
+Werkzeug==1.0.1
+cffi==1.14.1
+click==7.1.2
 itsdangerous==1.1.0
-pycparser==2.19
-six==1.12.0
+pycparser==2.20
+six==1.15.0

--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,14 @@
 set -e
 # Our internal BIND (started by Controller) is the official DNS resolver for this container
 echo nameserver 127.0.0.1 > /etc/resolv.conf
-# Start controller in background
-export CONTROLLER_PORT=5000
-export GOPATH=/go
-/usr/local/bin/python /root/controller.py &
 # Make Pebble sleep at most 5 seconds between auth checks (default is 15 seconds)
 export PEBBLE_VA_SLEEPTIME=5
 # Add three alternate roots with intermediate certs
 export PEBBLE_ALTERNATE_ROOTS=3
+# Start controller in background
+export CONTROLLER_PORT=5000
+export GOPATH=/go
+/usr/local/bin/python /root/controller.py &
 # Create Pebble config
 /usr/local/bin/python /root/create-pebble-config.py /go/src/github.com/letsencrypt/pebble/test/config/pebble-config.json
 # Start Pebble


### PR DESCRIPTION
Two features in the ACME test container I need to add testing for code yet-to-be-written for ansible-collections/community.crypto#89 (external account binding for acme_account) and ansible-collections/community.crypto#30 (OCSP revocation checking for certificate).

The Pebble upgrade is essentially just bumping to a newer version and adding some new config options. It works fine with the existing tests, I didn't try out the new features yet.

I've tested the OCSP part with OpenSSL CLI (https://github.com/ansible-collections/community.crypto/compare/main...felixfontein:ocsp-test):
```
OCSP Request Data:
    Version: 1 (0x0)
    Requestor List:
        Certificate ID:
          Hash Algorithm: sha1
          Issuer Name Hash: FF193F9527F879BB02B86E819C5236E7A9A3D8D1
          Issuer Key Hash: 1389463A5353BC31EB9838FC58670B0D5BC15EE4
          Serial Number: 0C5ED410847F3723
    Request Extensions:
        OCSP Nonce: 
            0410C2DF45FF51051DB19CC666053509B294
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: 1389463A5353BC31EB9838FC58670B0D5BC15EE4
    Produced At: Jul 27 15:14:25 2020 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: FF193F9527F879BB02B86E819C5236E7A9A3D8D1
      Issuer Key Hash: 1389463A5353BC31EB9838FC58670B0D5BC15EE4
      Serial Number: 0C5ED410847F3723
    Cert Status: good
    This Update: Jul 27 15:14:25 2020 GMT

    Response Extensions:
        OCSP Nonce: 
            0410C2DF45FF51051DB19CC666053509B294
    Signature Algorithm: sha256WithRSAEncryption
         aa:22:c8:41:9d:41:d4:81:da:eb:2c:e9:7a:16:f2:3e:42:bb:
         8a:2c:98:75:a0:73:62:40:b1:47:a9:8d:9a:7b:5b:74:5b:5c:
         96:bf:e6:17:ba:29:99:72:6b:6e:a9:e3:73:f8:1b:1c:ff:ee:
         be:00:ee:e3:5a:b8:a8:b6:22:31:92:3e:d5:aa:6e:65:d3:d4:
         48:2c:2a:bf:65:50:48:98:32:7c:ed:11:61:4b:2a:f7:b9:d3:
         4a:09:26:de:5c:b4:33:ee:8a:ba:e8:2b:7f:1a:1c:8b:76:21:
         78:af:12:8c:06:31:0d:32:9d:e9:82:2a:39:c3:85:5d:8e:7f:
         db:97:3d:f7:b1:1c:3e:2e:2a:d9:93:4d:89:95:29:5d:a1:ac:
         7d:54:1a:be:fc:52:76:b0:3a:f2:63:cd:9b:15:11:8f:e0:be:
         79:37:ca:ac:05:67:f2:b1:97:9e:9c:10:de:6d:3f:bb:4f:69:
         ca:30:df:e3:7c:e4:b5:4c:ff:d9:a6:c6:10:fe:89:f3:00:02:
         b6:96:dc:36:cd:c3:c4:fd:74:f5:56:c4:a4:d3:e8:00:97:01:
         c9:1e:90:b4:d9:22:c4:d6:84:34:1f:35:51:36:bc:84:79:cd:
         a3:9b:e0:84:0c:db:12:3e:69:2c:08:d0:5e:78:70:70:2e:81:
         11:49:9e:87
/root/ansible_collections/community/crypto/tests/output/.tmp/output_dir/cert-8.pem: good
        This Update: Jul 27 15:14:25 2020 GMT
```
For revoked cert:
```
OCSP Request Data:
    Version: 1 (0x0)
    Requestor List:
        Certificate ID:
          Hash Algorithm: sha1
          Issuer Name Hash: AB1B106511DDD3ABC56DAE3E32BE8804F9338733
          Issuer Key Hash: 264C6220053CE41307DF3F9DA4CD39EB4A8CEDFE
          Serial Number: 733FBCE13BD7D861
    Request Extensions:
        OCSP Nonce: 
            0410A80B2F2C96EAE6B2B518DF460C7F60C8
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: 264C6220053CE41307DF3F9DA4CD39EB4A8CEDFE
    Produced At: Jul 27 15:34:06 2020 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: AB1B106511DDD3ABC56DAE3E32BE8804F9338733
      Issuer Key Hash: 264C6220053CE41307DF3F9DA4CD39EB4A8CEDFE
      Serial Number: 733FBCE13BD7D861
    Cert Status: revoked
    Revocation Time: Jul 27 15:34:06 2020 GMT
    Revocation Reason: unspecified (0x0)
    This Update: Jul 27 15:34:06 2020 GMT

    Response Extensions:
        OCSP Nonce: 
            0410A80B2F2C96EAE6B2B518DF460C7F60C8
    Signature Algorithm: sha256WithRSAEncryption
         85:f9:34:4e:be:86:36:23:a7:aa:f5:3e:aa:86:2c:3e:83:dc:
         d7:b9:a0:6b:db:4f:0e:c6:4e:8f:0d:b3:0f:c6:e2:8e:d6:2a:
         00:93:ad:6e:f2:79:02:d3:fc:80:e6:80:e5:7f:7f:0a:1c:00:
         cf:3c:54:3a:d3:6b:92:5e:e0:6e:81:e1:a5:73:46:d6:5d:6d:
         ed:b4:e3:c5:3b:09:e8:69:9b:98:fb:37:eb:55:21:d7:d7:2c:
         ea:79:40:1f:3d:09:4c:f5:7f:05:8a:32:ee:88:85:4a:46:9f:
         fb:49:24:b5:9c:d0:b6:13:b2:80:33:77:b0:b0:91:a4:90:de:
         63:36:9f:81:1a:f9:f6:17:62:a2:d9:f3:dd:af:1b:6e:70:6a:
         d7:34:89:7d:e9:b3:a4:6f:00:25:cc:2a:e5:93:3b:03:1d:29:
         b6:45:61:80:26:97:2b:45:ff:00:73:71:33:60:6e:96:87:77:
         af:07:51:58:ae:b8:19:08:a5:a2:14:49:89:05:78:3b:df:a7:
         e1:ff:86:31:15:90:d5:d5:fe:c9:ae:be:5b:cd:dd:fe:40:f2:
         e7:81:4a:1f:f2:98:ef:70:b5:21:e2:42:56:0a:42:5a:60:42:
         dc:1c:34:8a:e0:dd:44:4d:db:91:d4:ac:07:af:9c:e4:30:cf:
         76:67:21:f9
/root/ansible_collections/community/crypto/tests/output/.tmp/output_dir/cert-3.pem: revoked
        This Update: Jul 27 15:34:06 2020 GMT
        Reason: unspecified
        Revocation Time: Jul 27 15:34:06 2020 GMT
```