### PR TITLE
Upgrade Pebble, dependencies, and runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.19-bullseye as builder
+FROM golang:1.23-bookworm AS builder
 # Install pebble
 ENV CGO_ENABLED=0
 ARG PEBBLE_REMOTE=
-ARG PEBBLE_CHECKOUT="d5fa73840ef4a2efa7870648ae174627ef001e9c"
+ARG PEBBLE_CHECKOUT="ddbc6bef1a71bf09e6ca5a7ed4d20ae3882c2bb7"
 WORKDIR /pebble-src
 RUN git clone https://github.com/letsencrypt/pebble.git /pebble-src && \
     if [ "${PEBBLE_REMOTE}" != "" ]; then \
@@ -14,7 +14,7 @@ RUN git clone https://github.com/letsencrypt/pebble.git /pebble-src && \
     fi && \
     go build -o /go/bin/pebble ./cmd/pebble
 
-FROM python:3.11-slim-bullseye
+FROM python:3.13-slim-bookworm
 # Install software
 ADD requirements.txt /root/
 RUN pip3 install -r /root/requirements.txt

--- a/create-pebble-config.py
+++ b/create-pebble-config.py
@@ -50,10 +50,14 @@ config = {
     "domainBlocklist": ["blocked-domain.example"],
     "profiles": {
       "default": {
+        "description": "Original Pebble settings",
+        "validityPeriod": 157766400,
+      },
+      "90days": {
         "description": "The profile you know and love",
         "validityPeriod": 7776000,
       },
-      "shortlived": {
+      "6days": {
         "description": "A short-lived cert profile, without actual enforcement",
         "validityPeriod": 518400,
       },

--- a/create-pebble-config.py
+++ b/create-pebble-config.py
@@ -32,6 +32,10 @@ config = {
     "privateKey": "test/certs/localhost/key.pem",
     "httpPort": 5000,
     "tlsPort": 5001,
+    "retryAfter": {
+        "authz": 1,
+        "order": 1,
+    },
     "ocspResponderURL": "http://{0}:5000/ocsp".format(own_ip),  # will be added later
     "externalAccountBindingRequired": False,
     "externalAccountMACKeys": {
@@ -40,9 +44,21 @@ config = {
       "kid-3": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
       "kid-4": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH",
       "kid-5": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
-      "kid-6": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
-    }
-  }
+      "kid-6": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH",
+      "kid-7": "HjudV5qnbreN-n9WyFSH-t4HXuEx_XFen45zuxY-G1h6fr74V3cUM_dVlwQZBWmc",
+    },
+    "domainBlocklist": ["blocked-domain.example"],
+    "profiles": {
+      "default": {
+        "description": "The profile you know and love",
+        "validityPeriod": 7776000,
+      },
+      "shortlived": {
+        "description": "A short-lived cert profile, without actual enforcement",
+        "validityPeriod": 518400,
+      },
+    },
+  },
 }
 
 with open(sys.argv[1], "wt") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
 # Requirements
-Flask==2.2.2
-pyOpenSSL==23.0.0
-dnslib==0.9.23
-cryptography==39.0.0
+Flask==3.1.0
+pyOpenSSL==24.3.0
+dnslib==0.9.25
+cryptography==44.0.0
 
 # Implicit requirements to make Python part reproducable
-Jinja2==3.1.2
-MarkupSafe==2.1.2
-Werkzeug==2.2.2
-cffi==1.15.1
-click==8.1.3
-cryptography==39.0.0
-dnslib==0.9.23
-itsdangerous==2.1.2
-pycparser==2.21
+Jinja2==3.1.5
+MarkupSafe==3.0.2
+Werkzeug==3.1.3
+blinker==1.9.0
+cffi==1.17.1
+click==8.1.8
+itsdangerous==2.2.0
+pycparser==2.22

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@ export GOPATH=/go
 /usr/local/bin/python /root/create-pebble-config.py /pebble-src/test/config/pebble-config.json
 # Start Pebble
 cd /pebble-src
-/go/bin/pebble -config /pebble-src/test/config/pebble-config.json -strict true
+/go/bin/pebble -config /pebble-src/test/config/pebble-config.json -strict


### PR DESCRIPTION
Upgrade Pebble, dependencies, and runtimes:

- Add "dns-account-01" support from draft-ietf-acme-scoped-dns-challenges;
- Implement latest draft-ietf-acme-ari spec;
- Add support for ACME Profiles;
- Upgrade dependencies and runtimes;
- Update config to use new EAB KID, `retryAfter`, and `domainBlocklist`.